### PR TITLE
Implement cyclic measurement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ I’ll make a video explaining this tool and the workflow in greater detail, but
 - About 100 sub-samples. I tried up to 1000 sub-samples and didn’t find much more of a difference.
 - remove 50% of the outliers
 - crank the smoothing way up
-- let the tool stay on for at least 5 minutes so the webcam sensor stays at a consistent temp. It will drift while getting up to temp. It might be best to test this on your own sensor by taking the same measurement from a cold start and time how long it takes before the samples stop drifting.
+- let the tool stay on for at least 5 minutes so the webcam sensor stays at a consistent temp. It will drift while getting up to temp. It might be best to test this on your own sensor by taking the same measurement from a cold start and time how long it takes before the samples stop drifting. File->Cyclic measurement feature can be used to achieve this easily.
 - Make sure nobody is walking around.
 - Don’t stand when taking a sample because it’ll pick up your leg muscles. Sit and don’t move.
 - Disable auto exposure and auto color temp. Disable anything that says auto in the device config with the extra attribute button (bottom left)

--- a/src/cycle.py
+++ b/src/cycle.py
@@ -1,0 +1,52 @@
+from PySide6.QtCore import QTimer, Signal
+from PySide6.QtWidgets import QDialog, QFormLayout, QSpinBox, QPushButton
+
+
+class CyclicMeasurementSetupWindow(QDialog):
+    """
+    Represents a non-modal dialog that allows to start/stop cyclic measurements and adjust the interval between measurements
+
+    Also handles starting/stopping the timer. Parent class is expected to actually perform the measurements when onMeasurementTrigger signal
+    is emitted.
+
+    """
+    cycle_time_sb: QSpinBox
+    cycle_timer: QTimer
+    pb_start: QPushButton
+    pb_stop: QPushButton
+
+    onMeasurementTrigger = Signal()
+
+    def __init__(self, parent) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Cyclic measurement setup")
+        self.setModal(False)
+        fl = QFormLayout(self)
+        self.cycle_time_sb = QSpinBox(self)
+        self.cycle_time_sb.setValue(60)
+        self.cycle_time_sb.setMinimum(10)
+        self.cycle_time_sb.setMaximum(3600)
+        fl.addRow("Cycle time (s)", self.cycle_time_sb)
+
+        self.pb_start = QPushButton(self)
+        self.pb_start.setText("Start")
+        self.pb_start.released.connect(self.start_cycle)
+
+        self.pb_stop = QPushButton(self)
+        self.pb_stop.setText("Stop")
+        self.pb_stop.setEnabled(False)
+        self.pb_stop.released.connect(self.stop_cycle)
+        fl.addRow(self.pb_start, self.pb_stop)
+        self.cycle_timer = QTimer(self)
+        self.cycle_timer.timeout.connect(self.onMeasurementTrigger)
+
+    def start_cycle(self) -> None:
+        self.cycle_timer.setInterval(1000 * self.cycle_time_sb.value())
+        self.cycle_timer.start()
+        self.pb_start.setEnabled(False)
+        self.pb_stop.setEnabled(True)
+
+    def stop_cycle(self) -> None:
+        self.cycle_timer.stop()
+        self.pb_stop.setEnabled(False)
+        self.pb_start.setEnabled(True)

--- a/src/main.py
+++ b/src/main.py
@@ -42,10 +42,11 @@ from src.Widgets import AnalyserWidget
 from src.Widgets import Graph
 from src.Widgets import PixmapWidget
 from src.Widgets import TableUnit
-
+from src.cycle import CyclicMeasurementSetupWindow
 
 # Define the main window
 class MainWindow(QMainWindow):  # type: ignore
+    cycle_dialog: CyclicMeasurementSetupWindow
     def __init__(self) -> None:
         super().__init__()
 
@@ -58,6 +59,13 @@ class MainWindow(QMainWindow):  # type: ignore
         export_action = QAction("Export CSV", self)
         export_action.triggered.connect(self.export_csv)
         file_menu.addAction(export_action)
+
+        cycle_action = QAction("Cyclic measurement", self)
+        cycle_action.triggered.connect(self.cycle_measurement_action)
+        self.cycle_dialog = CyclicMeasurementSetupWindow(self)
+        self.cycle_dialog.onMeasurementTrigger.connect(self.on_cyclic_measurement)
+        file_menu.addAction(cycle_action)
+
 
         # create a QAction for the "Exit" option
         exit_action = QAction("Exit", self)
@@ -276,6 +284,16 @@ class MainWindow(QMainWindow):  # type: ignore
                     else:
                         row_data.append("")
                 writer.writerow(row_data)
+
+    def cycle_measurement_action(self) -> None:
+        self.cycle_dialog.show()
+
+    def on_cyclic_measurement(self) -> None:
+        """Acquires sample (or zero, if not yet acquired)"""
+        if self.sample_btn.isEnabled():
+            self.sample_btn.click()
+        else:
+            self.zero_btn.click()
 
     def hightlight_sample(self) -> None:
         index = self.sample_table.currentRow()

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,7 @@ class MainWindow(QMainWindow):  # type: ignore
         export_action.triggered.connect(self.export_csv)
         file_menu.addAction(export_action)
 
+        # create "File->Cyclic measurement" action
         cycle_action = QAction("Cyclic measurement", self)
         cycle_action.triggered.connect(self.cycle_measurement_action)
         self.cycle_dialog = CyclicMeasurementSetupWindow(self)
@@ -286,10 +287,11 @@ class MainWindow(QMainWindow):  # type: ignore
                 writer.writerow(row_data)
 
     def cycle_measurement_action(self) -> None:
+        """Displays the cyclic measurement dialog"""
         self.cycle_dialog.show()
 
     def on_cyclic_measurement(self) -> None:
-        """Acquires sample (or zero, if not yet acquired)"""
+        """Executed on each cyclic measurement- acquires a sample (if zeroed), zeroes measurements otherwise."""
         if self.sample_btn.isEnabled():
             self.sample_btn.click()
         else:


### PR DESCRIPTION
It is sometimes useful to be able to acquire a series of measurements without manually clicking the zero/sample buttons. This PR implements such a feature.

Usage:
* File->Cyclic measurement opens a dialog where the measurement period can be selected (seconds).
* When "Start" button is clicked, a timer is started with the selected measurement period (that is- the first measurement will be acquired not when the Start button is clicked but after the chosen measurement period (intention: giving user some time to step away/sensor to settle if it's influenced by user clicking a button).
* Stop button stops the measurements.
* If user hasn't yet zeroed the measurements, it will be performed on the first cyclic measurement.