### PR TITLE
Reduce memory leakage related to np.polyfit

### DIFF
--- a/src/Widgets.py
+++ b/src/Widgets.py
@@ -25,6 +25,8 @@ from src.DataClasses import Sample
 from src.utils import get_units
 from src.utils import units_of_measurements
 
+import gc
+
 
 style = {
     "axes.grid": "True",
@@ -156,6 +158,10 @@ class Graph(QWidget):  # type: ignore
 
         self.ax.legend()
         self.canvas.draw()
+
+        #cleanup variables and garbage collect
+        del x,y
+        gc.collect()
 
 
 class PixmapWidget(QWidget):  # type: ignore


### PR DESCRIPTION
First of a few areas that I think we can cleanup some variables that are causing some memory leaks.  NOTE: I'm attempting to run this on a 4gb ram raspberry pi.  If it's ok, i'll continue working through the chain of finding what areas are causing memory utilization to spike.  With this change, I was able to double the amount of measurements I was able to take before getting a "invalid memory pointer" exception. 